### PR TITLE
Add python3.7rc image support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ services: docker
 #  - git clone -v https://github.com/vertexproject/synapse.git /tmp/synapse
 
 script:
-  - docker build -f ./python36/Dockerfile ./python36 | tee build_log.txt
+  - docker build -f ./python37/Dockerfile ./python37 | tee build_log.txt
   - export IMAGE_ID=`grep "Successfully built" build_log.txt | grep -v "msgpack" | cut -f 3 -d " "`
   - docker run $IMAGE_ID python -c "import msgpack; print(msgpack)"
   - docker run $IMAGE_ID python -c "import tornado; print(tornado)"

--- a/python37/Dockerfile
+++ b/python37/Dockerfile
@@ -1,0 +1,27 @@
+FROM python:3.7-rc
+
+MAINTAINER vEpiphyte <epiphyte@vertex.link>
+
+ENV PYTHONUNBUFFERED 1
+
+RUN apt-get update
+
+RUN mkdir -p /opt/reqs/build/
+
+COPY requirements.txt /opt/reqs/build/requirements.txt
+
+RUN pip install -r /opt/reqs/build/requirements.txt
+
+# Setup crontab from https://github.com/renskiy/cron-docker-image/blob/master/debian/Dockerfile
+RUN set -ex \
+    && apt-get clean && apt-get update \
+# install cron
+    && apt-get install -y cron \
+    && rm -rf /var/lib/apt/lists/* \
+# making logging pipe
+    && mkfifo --mode 0666 /var/log/cron.log \
+# make pam_loginuid.so optional for cron
+# see https://github.com/docker/docker/issues/5663#issuecomment-42550548
+    && sed --regexp-extended --in-place \
+    's/^session\s+required\s+pam_loginuid.so$/session optional pam_loginuid.so/' \
+    /etc/pam.d/cron

--- a/python37/requirements.txt
+++ b/python37/requirements.txt
@@ -1,0 +1,18 @@
+# Required packages  for synapse
+tornado==4.5.2
+cryptography==2.0.3
+pyOpenSSL==17.3.0
+msgpack-python==0.4.8
+xxhash==1.0.1
+lmdb==0.93
+# Delayed import
+psycopg2==2.7.3.1
+# Code style checks
+pycodestyle==2.3.1
+# Test related packages
+coverage==4.3.4 # pyup: ignore
+codecov==2.0.9
+pytest==3.2.2
+pytest-cov==2.5.1
+# Legacy test packages - nose is included but no longer used by Synapse.
+nose==1.3.7


### PR DESCRIPTION
Add preliminary support for 3.7 testing using the python:3.7-rc tag.